### PR TITLE
Add reason at Response

### DIFF
--- a/h11/_events.py
+++ b/h11/_events.py
@@ -44,7 +44,7 @@ class _EventBundle(object):
         if "headers" in self.__dict__:
             self.headers = _headers.normalize_and_validate(self.headers)
 
-        for field in ["method", "target", "http_version"]:
+        for field in ["method", "target", "http_version", "reason"]:
             if field in self.__dict__:
                 self.__dict__[field] = bytesify(self.__dict__[field])
 
@@ -123,8 +123,9 @@ class Request(_EventBundle):
 
 
 class _ResponseBase(_EventBundle):
-    _fields = ["status_code", "headers", "http_version"]
-    _defaults = {"http_version": b"1.1"}
+    _fields = ["status_code", "headers", "http_version", "reason"]
+    _defaults = {"http_version": b"1.1",
+                 "reason": b""}
 
 
 class InformationalResponse(_ResponseBase):

--- a/h11/_events.py
+++ b/h11/_events.py
@@ -151,6 +151,11 @@ class InformationalResponse(_ResponseBase):
        ``b"1.1"``. See :ref:`the HTTP version normalization rules
        <http_version-format>` for details.
 
+    .. attribute:: reason
+
+       The reason phrase of this response, as a byte string represent
+       short textual description of status code like ``b"OK"``.
+
     """
 
     def _validate(self):
@@ -182,6 +187,11 @@ class Response(_ResponseBase):
        The HTTP protocol version, represented as a byte string like
        ``b"1.1"``. See :ref:`the HTTP version normalization rules
        <http_version-format>` for details.
+
+    .. attribute:: reason
+
+       The reason phrase of this response, as a byte string represent
+       short textual description of status code like ``b"OK"``.
 
     """
     def _validate(self):

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -158,7 +158,7 @@ status_line = (
     r" "
     r"(?P<status_code>{status_code})"
     r" "
-    r"{reason_phrase}"
+    r"(?P<reason>{reason_phrase})"
     .format(**globals()))
 status_line_re = re.compile(status_line.encode("ascii"))
 

--- a/h11/_writers.py
+++ b/h11/_writers.py
@@ -56,7 +56,7 @@ def write_any_response(response, write):
     # from stdlib's http.HTTPStatus table. Or maybe just steal their enums
     # (either by import or copy/paste). We already accept them as status codes
     # since they're of type IntEnum < int.
-    write(bytesmod(b"HTTP/1.1 %s \r\n", (status_bytes,)))
+    write(bytesmod(b"HTTP/1.1 %s %s\r\n", (status_bytes, response.reason)))
     write_headers(response.headers, write)
 
 class BodyWriter(object):

--- a/h11/tests/test_connection.py
+++ b/h11/tests/test_connection.py
@@ -170,7 +170,7 @@ def test_client_talking_to_http10_server():
     assert c.our_state is DONE
     # No content-length, so Http10 framing for body
     assert (receive_and_get(c, b"HTTP/1.0 200 OK\r\n\r\n")
-            == [Response(status_code=200, headers=[], http_version="1.0")])
+            == [Response(status_code=200, headers=[], http_version="1.0", reason=b"OK")])
     assert c.our_state is MUST_CLOSE
     assert (receive_and_get(c, b"12345") == [Data(data=b"12345")])
     assert (receive_and_get(c, b"67890") == [Data(data=b"67890")])

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -26,21 +26,21 @@ SIMPLE_CASES = [
      b"GET /a HTTP/1.1\r\nhost: foo\r\nconnection: close\r\n\r\n"),
 
     ((SERVER, SEND_RESPONSE),
-     Response(status_code=200, headers=[("Connection", "close")]),
-     b"HTTP/1.1 200 \r\nconnection: close\r\n\r\n"),
+     Response(status_code=200, headers=[("Connection", "close")], reason=b"OK"),
+     b"HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n"),
 
     ((SERVER, SEND_RESPONSE),
-     Response(status_code=200, headers=[]),
-     b"HTTP/1.1 200 \r\n\r\n"),
+     Response(status_code=200, headers=[], reason=b"OK"),
+     b"HTTP/1.1 200 OK\r\n\r\n"),
 
     ((SERVER, SEND_RESPONSE),
      InformationalResponse(status_code=101,
-                           headers=[("Upgrade", "websocket")]),
-     b"HTTP/1.1 101 \r\nupgrade: websocket\r\n\r\n"),
+                           headers=[("Upgrade", "websocket")], reason=b"Upgrade"),
+     b"HTTP/1.1 101 Upgrade\r\nupgrade: websocket\r\n\r\n"),
 
     ((SERVER, SEND_RESPONSE),
-     InformationalResponse(status_code=101, headers=[]),
-     b"HTTP/1.1 101 \r\n\r\n"),
+     InformationalResponse(status_code=101, headers=[], reason=b"Upgrade"),
+     b"HTTP/1.1 101 Upgrade\r\n\r\n"),
 ]
 
 def dowrite(writer, obj):
@@ -119,7 +119,7 @@ def test_readers_unusual():
     tr(READERS[SERVER, SEND_RESPONSE],
        b"HTTP/1.0 200 OK\r\nSome: header\r\n\r\n",
        Response(status_code=200, headers=[("Some", "header")],
-                http_version="1.0"))
+                http_version="1.0", reason=b"OK"))
 
     # single-character header values (actually disallowed by the ABNF in RFC
     # 7230 -- this is a bug in the standard that we originally copied...)
@@ -127,20 +127,20 @@ def test_readers_unusual():
        b"HTTP/1.0 200 OK\r\n"
        b"Foo: a a a a a \r\n\r\n",
        Response(status_code=200, headers=[("Foo", "a a a a a")],
-                http_version="1.0"))
+                http_version="1.0", reason=b"OK"))
 
     # Empty headers -- also legal
     tr(READERS[SERVER, SEND_RESPONSE],
        b"HTTP/1.0 200 OK\r\n"
        b"Foo:\r\n\r\n",
        Response(status_code=200, headers=[("Foo", "")],
-                http_version="1.0"))
+                http_version="1.0", reason=b"OK"))
 
     tr(READERS[SERVER, SEND_RESPONSE],
        b"HTTP/1.0 200 OK\r\n"
        b"Foo: \t \t \r\n\r\n",
        Response(status_code=200, headers=[("Foo", "")],
-                http_version="1.0"))
+                http_version="1.0", reason=b"OK"))
 
     # obsolete line folding
     tr(READERS[CLIENT, IDLE],


### PR DESCRIPTION
Though there is useless for "reason" on the Response.
but I think keep it still better than discard when using reader to parse it.
So I create a PR to keep the reason on Response.

I had following modification:
1. Retrieve reason when using reader to parse the incoming data by modify the regex
2. Give reason default value empty string if the server don't care about it and will send empty string to client.

BTW, I know almost every client/server don't care about it,
but for my usage, my friend and I had implement a proxy server that was using h11,
and try keep original message that generated by client/server to prevent any misunderstand.
I had another modification on h11 that is related to it: keep original header field case.
I will create another PR after your feedback if you like it.

Thanks!