### PR TITLE
[rfc] Make sentinel objects instances of themselves

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -352,6 +352,23 @@ All of these behave the same, and their behavior is modeled after
 :data:`None`: they're opaque singletons, their :meth:`__repr__` is
 their name, and you compare them with ``is``.
 
+Finally, h11's constants have a quirky feature that can sometimes be
+useful: they are instances of themselves.
+
+.. ipython:: python
+
+   type(NEED_DATA) is NEED_DATA
+   type(PAUSED) is PAUSED
+
+The main application of this is that when handling the return value
+from :meth:`Connection.next_event`, which is sometimes an instance of
+an event class and sometimes :data:`NEED_DATA` or :data:`PAUSED`, you
+can always call ``type(event)`` to get something useful to dispatch
+one, using e.g. a handler table, :func:`functools.singledispatch`, or
+calling ``getattr(some_object, "handle_" +
+type(event).__name__)``. Not that this kind of dispatch-based strategy
+is always the best approach -- but the option is there if you want it.
+
 
 The Connection object
 ---------------------

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -3,6 +3,15 @@ History of changes
 
 .. currentmodule:: h11
 
+vNEXT (????-??-??)
+-------------------
+
+* Made it so that sentinels are instances of themselves, to enable
+  certain dispatch tricks on the return value of
+  :func:`Connection.next_event` (see `issue #8
+  <https://github.com/njsmith/h11/issues/8>`).
+
+
 v0.6.0 (2016-10-24)
 -------------------
 

--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -6,7 +6,7 @@ from ._events import *
 # Import all state sentinels
 from ._state import *
 # Import the internal things we need
-from ._util import LocalProtocolError, RemoteProtocolError, Sentinel
+from ._util import LocalProtocolError, RemoteProtocolError, make_sentinel
 from ._state import ConnectionState, _SWITCH_UPGRADE, _SWITCH_CONNECT
 from ._headers import (
     get_comma_header, set_comma_header, has_expect_100_continue,
@@ -18,8 +18,8 @@ from ._writers import WRITERS
 # Everything in __all__ gets re-exported as part of the h11 public API.
 __all__ = ["Connection", "NEED_DATA", "PAUSED"]
 
-NEED_DATA = Sentinel("NEED_DATA")
-PAUSED = Sentinel("PAUSED")
+NEED_DATA = make_sentinel("NEED_DATA")
+PAUSED = make_sentinel("PAUSED")
 
 # If we ever have this much buffered without it making a complete parseable
 # event, we error out. The only time we really buffer is when reading the
@@ -418,7 +418,7 @@ class Connection(object):
                 "Can't receive data when peer state is ERROR")
         try:
             event = self._extract_next_receive_event()
-            if type(event) is not Sentinel:
+            if event not in [NEED_DATA, PAUSED]:
                 self._process_event(self.their_role, event)
                 self._receive_buffer.compress()
             if event is NEED_DATA:

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -112,7 +112,7 @@
 # script to keep it in sync!
 
 from ._events import *
-from ._util import LocalProtocolError, Sentinel
+from ._util import LocalProtocolError, make_sentinel
 
 # Everything in __all__ gets re-exported as part of the h11 public API.
 __all__ = []
@@ -125,7 +125,7 @@ sentinels = ("CLIENT SERVER "
              # Switch types
              "_SWITCH_UPGRADE _SWITCH_CONNECT").split()
 for token in sentinels:
-    globals()[token] = Sentinel(token)
+    globals()[token] = make_sentinel(token)
 
 __all__ += [s for s in sentinels if not s.startswith("_")]
 

--- a/h11/tests/test_util.py
+++ b/h11/tests/test_util.py
@@ -53,11 +53,18 @@ def test_validate():
     with pytest.raises(LocalProtocolError):
         validate(my_re, b"0.1\n")
 
-def test_Sentinel():
-    S = Sentinel("S")
+def test_make_sentinel():
+    S = make_sentinel("S")
     assert repr(S) == "S"
     assert S == S
+    assert type(S).__name__ == "S"
     assert S in {S}
+    assert type(S) is S
+    S2 = make_sentinel("S2")
+    assert repr(S2) == "S2"
+    assert S != S2
+    assert S not in {S2}
+    assert type(S) is not type(S2)
 
 def test_bytesify():
     assert bytesify(b"123") == b"123"


### PR DESCRIPTION
This is a slightly wacky solution to #8. By "slightly wacky" I mean that contains the following line of code:

``` python
cls.__class__ = cls
```

Based on watching some of his talks I feel fairly confident that @dabeaz will appreciate this, but I am less certain about whether it's actually a good idea, so would appreciate comments ;-).

Actually, my main hesitation is that I'm not really sure whether doing table-based dispatch on the return value from `next_event` ever makes much sense -- in my experience so far, libraries usually have a pretty small and specific set of events that they're looking for at any given time. But maybe it's useful for those who like more declarative state-machine kind of approaches? And it's not a big deal to support; it's like 2 extra lines of code that don't touch anything else in h11 at all.

This is a reworked version of @RazerM's work in #11.
