### PR TITLE
restrict newlines in header values

### DIFF
--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -56,6 +56,7 @@ from ._util import LocalProtocolError, bytesify, validate
 # Maybe a dict-of-lists would be better?
 
 _content_length_re = re.compile(br"[0-9]+")
+_header_value_re = re.compile(br"[\x21-\xff]+(?:[ \t]+[\x21-\xff]+)*|^$")
 
 def normalize_and_validate(headers):
     new_headers = []
@@ -64,6 +65,9 @@ def normalize_and_validate(headers):
     for name, value in headers:
         name = bytesify(name).lower()
         value = bytesify(value).strip()
+        # Ensure header value doesn't contain any non-permitted characters
+        validate(_header_value_re, value,
+                 "Illegal header value {}".format(value))
         # "No whitespace is allowed between the header field-name and colon.
         # In the past, differences in the handling of such whitespace have led
         # to security vulnerabilities in request routing and response

--- a/h11/tests/test_headers.py
+++ b/h11/tests/test_headers.py
@@ -15,6 +15,14 @@ def test_normalize_and_validate():
     # leading/trailing whitespace on values is stripped
     assert normalize_and_validate([("foo", "   bar  ")]) == [(b"foo", b"bar")]
 
+    # no return or NUL characters in values
+    with pytest.raises(LocalProtocolError):
+        normalize_and_validate([("foo", "bar\r\nbaz")])
+    with pytest.raises(LocalProtocolError):
+        normalize_and_validate([("foo", "bar\nbaz")])
+    with pytest.raises(LocalProtocolError):
+        normalize_and_validate([("foo", "bar\x00baz")])
+
     # content-length
     assert (normalize_and_validate([("Content-Length", "1")])
             == [(b"content-length", b"1")])


### PR DESCRIPTION
This should address #5 by raising an exception in the event of return characters in the header field value. I also added an exception for requests sending both Content-Length and Transfer-Encoding. [RFC 7230 3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2) is pretty clear about that, so I felt like it was a safe call.

The only other major issues I can think of for cleaning up outgoing headers are already covered. Leading/trailing whitespace is taken care of by the `strip` on value, and trailing space on the name is handled the same way.

Let me know if I'm overlooking anything else.