### PR TITLE
Skip header validation for data parsed off the wire

### DIFF
--- a/h11/_events.py
+++ b/h11/_events.py
@@ -24,6 +24,7 @@ class _EventBundle(object):
     _defaults = {}
 
     def __init__(self, **kwargs):
+        _parsed = kwargs.pop("_parsed", False)
         allowed = set(self._fields)
         for kwarg in kwargs:
             if kwarg not in allowed:
@@ -42,15 +43,17 @@ class _EventBundle(object):
         # Special handling for some fields
 
         if "headers" in self.__dict__:
-            self.headers = _headers.normalize_and_validate(self.headers)
+            self.headers = _headers.normalize_and_validate(
+                self.headers, _parsed=_parsed)
 
-        for field in ["method", "target", "http_version", "reason"]:
-            if field in self.__dict__:
-                self.__dict__[field] = bytesify(self.__dict__[field])
+        if not _parsed:
+            for field in ["method", "target", "http_version", "reason"]:
+                if field in self.__dict__:
+                    self.__dict__[field] = bytesify(self.__dict__[field])
 
-        if "status_code" in self.__dict__:
-            if not isinstance(self.status_code, int):
-                raise LocalProtocolError("status code must be integer")
+            if "status_code" in self.__dict__:
+                if not isinstance(self.status_code, int):
+                    raise LocalProtocolError("status code must be integer")
 
         self._validate()
 

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -63,7 +63,9 @@ def maybe_read_from_IDLE_client(buf):
     if not lines:
         raise LocalProtocolError("no request line received")
     matches = validate(request_line_re, lines[0])
-    return Request(headers=list(_decode_header_lines(lines[1:])), **matches)
+    return Request(headers=list(_decode_header_lines(lines[1:])),
+                   _parsed=True,
+                   **matches)
 
 status_line_re = re.compile(status_line.encode("ascii"))
 
@@ -79,7 +81,9 @@ def maybe_read_from_SEND_RESPONSE_server(buf):
         matches["reason"] = b""
     status_code = matches["status_code"] = int(matches["status_code"])
     class_ = InformationalResponse if status_code < 200 else Response
-    return class_(headers=list(_decode_header_lines(lines[1:])), **matches)
+    return class_(headers=list(_decode_header_lines(lines[1:])),
+                  _parsed=True,
+                  **matches)
 
 
 class ContentLengthReader:


### PR DESCRIPTION
The parser already validates, so there's no need to do it twice, and
it's a bit expensive.

On my laptop, on the benchmark in bench/, I get:
  CPython 3.5: ~4386 req/sec -> ~5141 req/sec = 17% speedup
  PyPy 5.6.0: ~19311 req/sec -> ~21106 req/sec = 9% speedup