### PR TITLE
Remove slow bytesify calls when they are avoidable

### DIFF
--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -98,6 +98,8 @@ def get_comma_header(headers, name, lowercase=True):
     # Should only be used for headers whose value is a list of comma-separated
     # values. Use lowercase=True for case-insensitive ones.
     #
+    # The header name `name` is expected to be lower-case bytes.
+    #
     # Connection: meets these criteria (including cast insensitivity).
     #
     # Content-Length: technically is just a single value (1*DIGIT), but the
@@ -130,7 +132,6 @@ def get_comma_header(headers, name, lowercase=True):
     # lowercase=False.
     #
     out = []
-    name = bytesify(name).lower()
     for found_name, found_raw_value in headers:
         if found_name == name:
             if lowercase:
@@ -142,7 +143,7 @@ def get_comma_header(headers, name, lowercase=True):
     return out
 
 def set_comma_header(headers, name, new_values):
-    name = bytesify(name).lower()
+    # The header name `name` is expected to be lower-case bytes.
     new_headers = []
     for found_name, found_raw_value in headers:
         if found_name != name:
@@ -158,5 +159,5 @@ def has_expect_100_continue(request):
     if request.http_version < b"1.1":
         return False
     # Expect: 100-continue is case *sensitive*
-    expect = get_comma_header(request.headers, "Expect", lowercase=False)
+    expect = get_comma_header(request.headers, b"expect", lowercase=False)
     return (b"100-continue" in expect)

--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -67,9 +67,9 @@ def normalize_and_validate(headers):
     for name, value in headers:
         name = bytesify(name).lower()
         value = bytesify(value)
-        validate(_field_name_re, name, "Illegal header name {!r}".format(name))
+        validate(_field_name_re, name, "Illegal header name {!r}", name)
         validate(_field_value_re, value,
-                 "Illegal header value {!r}".format(value))
+                 "Illegal header value {!r}", value)
         if name == b"content-length":
             if saw_content_length:
                 raise LocalProtocolError("multiple Content-Length headers")

--- a/h11/_util.py
+++ b/h11/_util.py
@@ -1,4 +1,5 @@
 import sys
+import re
 
 __all__ = ["ProtocolError", "LocalProtocolError", "RemoteProtocolError",
            "validate", "make_sentinel", "bytesify"]
@@ -78,12 +79,14 @@ class LocalProtocolError(ProtocolError):
 class RemoteProtocolError(ProtocolError):
     pass
 
-# Equivalent to python 3.4's regex.fullmatch(data)
-def _fullmatch(regex, data):  # version specific: Python < 3.4
-    match = regex.match(data)
-    if match and match.end() != len(data):
-        match = None
-    return match
+try:
+    _fullmatch = type(re.compile('')).fullmatch
+except AttributeError:
+    def _fullmatch(regex, data):  # version specific: Python < 3.4
+        match = regex.match(data)
+        if match and match.end() != len(data):
+            match = None
+        return match
 
 def validate(regex, data, msg="malformed data", msgargs=()):
     match = _fullmatch(regex, data)

--- a/h11/_util.py
+++ b/h11/_util.py
@@ -85,10 +85,10 @@ def _fullmatch(regex, data):  # version specific: Python < 3.4
         match = None
     return match
 
-def validate(regex, data, msg="malformed data"):
+def validate(regex, data, msg="malformed data", msgargs=()):
     match = _fullmatch(regex, data)
     if not match:
-        raise LocalProtocolError(msg)
+        raise LocalProtocolError(msg.format(*msgargs))
     return match.groupdict()
 
 # Sentinel values

--- a/h11/tests/test_headers.py
+++ b/h11/tests/test_headers.py
@@ -64,15 +64,15 @@ def test_get_set_comma_header():
         ("connectiON", "fOo,, , BAR"),
     ])
 
-    assert get_comma_header(headers, "connECtion") == [
+    assert get_comma_header(headers, b"connection") == [
         b"close", b"foo", b"bar"]
-    assert get_comma_header(headers, "connECtion", lowercase=False) == [
+    assert get_comma_header(headers, b"connection", lowercase=False) == [
         b"close", b"fOo", b"BAR"]
 
-    set_comma_header(headers, "NewThing", ["a", "b"])
+    set_comma_header(headers, b"newthing", ["a", "b"])
 
     with pytest.raises(LocalProtocolError):
-        set_comma_header(headers, "NewThing", ["  a", "b"])
+        set_comma_header(headers, b"newthing", ["  a", "b"])
 
     assert headers == [
         (b"connection", b"close"),
@@ -82,7 +82,7 @@ def test_get_set_comma_header():
         (b"newthing", b"b"),
     ]
 
-    set_comma_header(headers, "whatever", ["different thing"])
+    set_comma_header(headers, b"whatever", ["different thing"])
 
     assert headers == [
         (b"connection", b"close"),


### PR DESCRIPTION
`bytesify` shows up prominently in profiles (of a basic sync socket server
fed by netcat):

```
    prof.prof% sort tottime

    prof.prof% stats 10

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   200000    0.677    0.000    3.324    0.000 h11/_connection.py:226(_process_event)
   680000    0.447    0.000    0.690    0.000 h11/_util.py:114(bytesify)
   120000    0.438    0.000    0.438    0.000 {method 'sendall' of '_socket.socket' objects}
    80000    0.437    0.000    1.319    0.000 h11/_events.py:26(__init__)
   400000    0.435    0.000    1.175    0.000 h11/_headers.py:97(get_comma_header)
   240000    0.351    0.000    1.299    0.000 h11/_connection.py:285(_respond_to_state_changes)
   200000    0.337    0.000    0.412    0.000 h11/_state.py:256(_fire_state_triggered_transitions)
   360000    0.292    0.000    0.292    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
   120034    0.278    0.000    4.956    0.000 h11/_connection.py:376(next_event)
   120000    0.267    0.000    2.699    0.000 h11/_connection.py:470(send_with_data_passthrough)

    prof.prof% callers bytesify
                                    ncalls  tottime  cumtime
    h11/_util.py:114(bytesify)  <-  120000    0.030    0.030  h11/_events.py:26(__init__)
                                    160000    0.041    0.041  h11/_headers.py:63(normalize_and_validate)
                                    400000    0.376    0.619  h11/_headers.py:97(get_comma_header)
```

Since the `name` argument to the functions `get_comma_header` and
`set_comma_header` is always a "compile-time constant", and is what
bytesify is called on, we can completely avoid it if we just require
that the passed-in name already be bytes. By also requiring it be
lowercase, we can remove the call to `lower()` as well:

```
    prof.prof% stats 10

      ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      200000    0.676    0.000    2.546    0.000 h11/_connection.py:226(_process_event)
      120000    0.552    0.000    0.552    0.000 {method 'sendall' of '_socket.socket' objects}
       80000    0.397    0.000    1.255    0.000 h11/_events.py:26(__init__)
      240000    0.332    0.000    0.955    0.000 h11/_connection.py:285(_respond_to_state_changes)
      200000    0.325    0.000    0.401    0.000 h11/_state.py:256(_fire_state_triggered_transitions)
      360000    0.287    0.000    0.287    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
      120034    0.274    0.000    4.336    0.000 h11/_connection.py:376(next_event)
      400000    0.263    0.000    0.344    0.000 h11/_headers.py:97(get_comma_header)
      120000    0.260    0.000    2.284    0.000 h11/_connection.py:470(send_with_data_passthrough)
       40033    0.221    0.000    2.205    0.000 h11/_readers.py:59(maybe_read_from_IDLE_client)

    prof.prof% callers bytesify
                                    ncalls  tottime  cumtime
    h11/_util.py:114(bytesify)  <-  120000    0.024    0.024  h11/_events.py:26(__init__)
                                    160000    0.041    0.041  h11/_headers.py:63(normalize_and_validate)
```